### PR TITLE
[PATCH] Set Icon size limits,  Small refactor to shorten the code and ease maintenance

### DIFF
--- a/Notification Agent Core/Controllers/HelpBuilder.swift
+++ b/Notification Agent Core/Controllers/HelpBuilder.swift
@@ -11,93 +11,93 @@ import Foundation
 
 public final class HelpBuilder {
     static let popupArguments: [String] = ["-type".green(),
-                                      "-bar_title".yellow(),
-                                      "-title".yellow(),
-                                      "-subtitle".yellow(),
-                                      "-icon_path".yellow(),
-                                      "-icon_width".yellow(),
-                                      "-icon_height".yellow(),
-                                      "-accessory_view_type".yellow(),
-                                      "-accessory_view_payload".yellow(),
-                                      "-secondary_accessory_view_type".yellow(),
-                                      "-secondary_accessory_view_payload".yellow(),
-                                      "-main_button_label".yellow(),
-                                      "-main_button_cta_type".yellow(),
-                                      "-main_button_cta_payload".yellow(),
-                                      "-secondary_button_label".yellow(),
-                                      "-secondary_button_cta_type".yellow(),
-                                      "-secondary_button_cta_payload".yellow(),
-                                      "-tertiary_button_label".yellow(),
-                                      "-tertiary_button_cta_type".yellow(),
-                                      "-tertiary_button_cta_payload".yellow(),
-                                      "-help_button_cta_type".yellow(),
-                                      "-help_button_cta_payload".yellow(),
-                                      "-timeout".yellow(),
-                                      "-always_on_top".yellow(),
-                                      "-silent".yellow(),
-                                      "-miniaturizable".yellow(),
-                                      "-position".yellow()]
+                                           "-bar_title".yellow(),
+                                           "-title".yellow(),
+                                           "-subtitle".yellow(),
+                                           "-icon_path".yellow(),
+                                           "-icon_width".yellow(),
+                                           "-icon_height".yellow(),
+                                           "-accessory_view_type".yellow(),
+                                           "-accessory_view_payload".yellow(),
+                                           "-secondary_accessory_view_type".yellow(),
+                                           "-secondary_accessory_view_payload".yellow(),
+                                           "-main_button_label".yellow(),
+                                           "-main_button_cta_type".yellow(),
+                                           "-main_button_cta_payload".yellow(),
+                                           "-secondary_button_label".yellow(),
+                                           "-secondary_button_cta_type".yellow(),
+                                           "-secondary_button_cta_payload".yellow(),
+                                           "-tertiary_button_label".yellow(),
+                                           "-tertiary_button_cta_type".yellow(),
+                                           "-tertiary_button_cta_payload".yellow(),
+                                           "-help_button_cta_type".yellow(),
+                                           "-help_button_cta_payload".yellow(),
+                                           "-timeout".yellow(),
+                                           "-always_on_top".yellow(),
+                                           "-silent".yellow(),
+                                           "-miniaturizable".yellow(),
+                                           "-position".yellow()]
     static let bannerArguments: [String] = ["-type".green(),
-                                      "-title".yellow(),
-                                      "-subtitle".yellow(),
-                                      "-main_button_label".yellow(),
-                                      "-main_button_cta_type".yellow(),
-                                      "-main_button_cta_payload".yellow(),
-                                      "-secondary_button_label".yellow(),
-                                      "-secondary_button_cta_type".yellow(),
-                                      "-secondary_button_cta_payload".yellow(),
-                                      "-tertiary_button_label".yellow(),
-                                      "-tertiary_button_cta_type".yellow(),
-                                      "-tertiary_button_cta_payload".yellow()]
+                                            "-title".yellow(),
+                                            "-subtitle".yellow(),
+                                            "-main_button_label".yellow(),
+                                            "-main_button_cta_type".yellow(),
+                                            "-main_button_cta_payload".yellow(),
+                                            "-secondary_button_label".yellow(),
+                                            "-secondary_button_cta_type".yellow(),
+                                            "-secondary_button_cta_payload".yellow(),
+                                            "-tertiary_button_label".yellow(),
+                                            "-tertiary_button_cta_type".yellow(),
+                                            "-tertiary_button_cta_payload".yellow()]
     static let onboardingArguments: [String] = ["-type".green(),
-                                           "-payload".green()]
+                                                "-payload".green()]
     static let popupDescriptions: [String] = ["[ popup ]".red() + "\n      The UI type of the notification.\n      Example: -type popup",
-                                         "\n      The bar title.\n      Example: -bar_title \"Bar Title\"",
-                                         "\n      The title of the notification.\n      Suggested length < 120 characters.\n      Allowed length < 240 characters.\n      Example: -title \"Title\"",
-                                         "\n      The subtitle of the notification. It supports MarkDown text.\n      Example: -subtitle \"Subtitle\"",
-                                         "\n      The custom icon path defined for this notification.\n      Example: -icon_path \"~/Icon/Path.png\"",
-                                         "\n      The custom icon width defined for this notification.\n      Example: -icon_width \"150\"",
-                                         "\n      The custom icon height defined for this notification.\n      Example: -icon_height \"150\"",
-                                         "[ whitebox | timer | image | video | progressbar | input | secureinput | dropdown | html | htmlwhitebox | checklist ]".red() + "\n      The UI type for the needed accessory view.\n      Example: -accessory_view_type whitebox",
-                                         "\n      The payload for the accessory view:\n      - Text for " + "[ whitebox ]".red() + " view type;\n      - Text for " + "[ timer ]".red() + " view type. This will be timer's label. Use \"%@\" to define timer's position inside the label. Use " + "[ -timeout ]".yellow() + " argument to define timer's duration;\n      - File path/link for " + "[ image ]".red() + " view type;\n      - Text with the format " + "\"/url TEXT /autoplay /delay INT\" ".green() + "for " + "[ video ]".red() + " view type;\n      - Text with the format " + "\"/percent DOUBLE /top_message TEXT /bottom_message TEXT /user_interaction_enabled BOOL /user_interruption_allowed BOOL\" ".green() + "for " + "[ progressbar ]".red() + " view type;\n      - Text with the format " + "\"/placeholder TEXT /title TEXT /required\" ".green() + "for the " + "[ input | secureinput ]".red() + " view type.\n      - Text with the format " + "\"/list ITEM\\nITEM\\nITEM /selected INT /placeholder TEXT /title TEXT\" ".green() + "for " + "[ dropdown ]".red() + " view type;\n      - Text with HTML format for " + "[ html | htmlwhitebox ]".red() + " view type;\n      - Text with the format " + "\"/list ITEM\\nITEM\\nITEM /required /complete /title TEXT\" ".green() + "for " + "[ checklist ]".red() + " view type. To read more about the usage of /complete and /required look at the project wiki;\n      Example 1: -accessory_view_payload \"This is the time left: %@\"\n      Example 2: -accessory_view_payload \"/percent 0 /top_message This is the top message /bottom_message This is the bottom message\";\n      Example 3: -accessory_view_payload \"/percent indeterminate /top_message This is the top message /bottom_message This is the bottom message\";\n      Example 4: -accessory_view_payload \"<h1>Hello, world!</h1>this is a line of text<br><br><code>this is a code block<br>this is the second line of a code block</code><br>this is <span style=\"color: #ff0000\">red</span> text\".",
-                                         "\n      Same as for accessory_view_type argument.",
-                                         "\n      Same as for accessory_view_payload argument.",
-                                         "\n      The label of the main button.\n      Example: -main_button_label \"Main button title\"",
-                                         "[ none | link ]".red() + "\n      The call to action type for the main button (default: none -> exit).\n      Example: -main_button_cta_type link",
-                                         "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -main_button_cta_payload \"URL\"",
-                                         "\n      The label of the secondary button.\n      Example: -secondary_button_label \"Secondary button title\"",
-                                         "[ none | link ]".red() + "\n      The call to action type for the secondary button (default: none -> exit).\n      Example: -secondary_button_cta_type link",
-                                         "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -secondary_button_cta_payload \"URL\"",
-                                         "\n      The label of the tertiary button.\n      Example: -tertiary_button_label \"Tertiary button title\"",
-                                         "[ link | exitlink ]".red() + "\n      The call to action type for the tertiary button.\n      Example: -tertiary_button_cta_type link",
-                                         "\n      A mandatory URL if " + "[ link ]".red() + " cta type defined, optional if " + "[ exitlink ]".red() + " cta defined.\n      Example: -tertiary_button_cta_payload \"URL\"",
-                                         "[ link | infopopup ]".red() + "\n      The call to action type for the help button.\n      Example: -help_button_cta_type link",
-                                         "\n      An URL for " + "[ link ]".red() + " cta type or text for " + "[ infopopup ]".red() + " cta type.\n      Example: -help_button_cta_payload \"URL\"",
-                                         "\n      The timeout for the notification. After this amount of seconds the agent exit with the timeout exit code.\n      Example: -timeout 300",
-                                         "\n      Flag that tells the agent to keep the pop-up always on top of the window hierarchy.\n      Example: -always_on_top",
-                                         "\n      Flag that tells the agent to not reproduce any sound when the pop-up appear.\n      Example: -silent",
-                                         "\n      Flag that allows the UI to show the \"miniaturize\" button for the pop-up window.\n      Example: -miniaturizable",
-                                         "[ center | top_right | top_left | bottom_right | bottom_left ]".red() + "\n      Tells the app where to place the pop-up window.\n      Example: -position center"]
-
+                                              "\n      The bar title.\n      Example: -bar_title \"Bar Title\"",
+                                              "\n      The title of the notification.\n      Suggested length < 120 characters.\n      Allowed length < 240 characters.\n      Example: -title \"Title\"",
+                                              "\n      The subtitle of the notification. It supports MarkDown text.\n      Example: -subtitle \"Subtitle\"",
+                                              "\n      The custom icon path defined for this notification.\n      Example: -icon_path \"~/Icon/Path.png\"",
+                                              "\n      The custom icon width defined for this notification. Max. width = 150\n      Example: -icon_width \"150\"",
+                                              "\n      The custom icon height defined for this notification. Max. height = 300\n      Example: -icon_height \"150\"",
+                                              "[ whitebox | timer | image | video | progressbar | input | secureinput | dropdown | html | htmlwhitebox | checklist ]".red() + "\n      The UI type for the needed accessory view.\n      Example: -accessory_view_type whitebox",
+                                              "\n      The payload for the accessory view:\n      - Text for " + "[ whitebox ]".red() + " view type;\n      - Text for " + "[ timer ]".red() + " view type. This will be timer's label. Use \"%@\" to define timer's position inside the label. Use " + "[ -timeout ]".yellow() + " argument to define timer's duration;\n      - File path/link for " + "[ image ]".red() + " view type;\n      - Text with the format " + "\"/url TEXT /autoplay /delay INT\" ".green() + "for " + "[ video ]".red() + " view type;\n      - Text with the format " + "\"/percent DOUBLE /top_message TEXT /bottom_message TEXT /user_interaction_enabled BOOL /user_interruption_allowed BOOL\" ".green() + "for " + "[ progressbar ]".red() + " view type;\n      - Text with the format " + "\"/placeholder TEXT /title TEXT /required\" ".green() + "for the " + "[ input | secureinput ]".red() + " view type.\n      - Text with the format " + "\"/list ITEM\\nITEM\\nITEM /selected INT /placeholder TEXT /title TEXT\" ".green() + "for " + "[ dropdown ]".red() + " view type;\n      - Text with HTML format for " + "[ html | htmlwhitebox ]".red() + " view type;\n      - Text with the format " + "\"/list ITEM\\nITEM\\nITEM /required /complete /title TEXT\" ".green() + "for " + "[ checklist ]".red() + " view type. To read more about the usage of /complete and /required look at the project wiki;\n      Example 1: -accessory_view_payload \"This is the time left: %@\"\n      Example 2: -accessory_view_payload \"/percent 0 /top_message This is the top message /bottom_message This is the bottom message\";\n      Example 3: -accessory_view_payload \"/percent indeterminate /top_message This is the top message /bottom_message This is the bottom message\";\n      Example 4: -accessory_view_payload \"<h1>Hello, world!</h1>this is a line of text<br><br><code>this is a code block<br>this is the second line of a code block</code><br>this is <span style=\"color: #ff0000\">red</span> text\".",
+                                              "\n      Same as for accessory_view_type argument.",
+                                              "\n      Same as for accessory_view_payload argument.",
+                                              "\n      The label of the main button.\n      Example: -main_button_label \"Main button title\"",
+                                              "[ none | link ]".red() + "\n      The call to action type for the main button (default: none -> exit).\n      Example: -main_button_cta_type link",
+                                              "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -main_button_cta_payload \"URL\"",
+                                              "\n      The label of the secondary button.\n      Example: -secondary_button_label \"Secondary button title\"",
+                                              "[ none | link ]".red() + "\n      The call to action type for the secondary button (default: none -> exit).\n      Example: -secondary_button_cta_type link",
+                                              "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -secondary_button_cta_payload \"URL\"",
+                                              "\n      The label of the tertiary button.\n      Example: -tertiary_button_label \"Tertiary button title\"",
+                                              "[ link | exitlink ]".red() + "\n      The call to action type for the tertiary button.\n      Example: -tertiary_button_cta_type link",
+                                              "\n      A mandatory URL if " + "[ link ]".red() + " cta type defined, optional if " + "[ exitlink ]".red() + " cta defined.\n      Example: -tertiary_button_cta_payload \"URL\"",
+                                              "[ link | infopopup ]".red() + "\n      The call to action type for the help button.\n      Example: -help_button_cta_type link",
+                                              "\n      An URL for " + "[ link ]".red() + " cta type or text for " + "[ infopopup ]".red() + " cta type.\n      Example: -help_button_cta_payload \"URL\"",
+                                              "\n      The timeout for the notification. After this amount of seconds the agent exit with the timeout exit code.\n      Example: -timeout 300",
+                                              "\n      Flag that tells the agent to keep the pop-up always on top of the window hierarchy.\n      Example: -always_on_top",
+                                              "\n      Flag that tells the agent to not reproduce any sound when the pop-up appear.\n      Example: -silent",
+                                              "\n      Flag that allows the UI to show the \"miniaturize\" button for the pop-up window.\n      Example: -miniaturizable",
+                                              "[ center | top_right | top_left | bottom_right | bottom_left ]".red() + "\n      Tells the app where to place the pop-up window.\n      Example: -position center"]
+    
     static let bannerDescriptions: [String] = ["[ banner | alert ]".red() + "\n      The UI type of the notification.\n      Example: -type banner",
-                                         "\n      The title of the notification.\n      Example: -title \"Title\"",
-                                         "\n      The subtitle of the notification. It supports MarkDown text.\n      Example: -subtitle \"Subtitle\"",
-                                         "\n      The label of the main button.\n      Example: -main_button_label \"Main button title\"",
-                                         "[ none | link ]".red() + "\n      The call to action type for the main button (default: none -> exit).\n      Example: -main_button_cta_type link",
-                                         "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -main_button_cta_payload \"URL\"",
-                                         "\n      The label of the secondary button.\n      Example: -secondary_button_label \"Secondary button title\"",
-                                         "[ none | link ]".red() + "\n      The call to action type for the secondary button (default: none -> exit).\n      Example: -secondary_button_cta_type link",
-                                         "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -secondary_button_cta_payload \"URL\"",
-                                         "\n      The label of the tertiary button.\n      Example: -tertiary_button_label \"Tertiary button title\"",
-                                         "[ none | link ]".red() + "\n      The call to action type for the tertiary button.\n      Example: -tertiary_button_cta_type link",
-                                         "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -tertiary_button_cta_payload \"URL\""]
+                                               "\n      The title of the notification.\n      Example: -title \"Title\"",
+                                               "\n      The subtitle of the notification. It supports MarkDown text.\n      Example: -subtitle \"Subtitle\"",
+                                               "\n      The label of the main button.\n      Example: -main_button_label \"Main button title\"",
+                                               "[ none | link ]".red() + "\n      The call to action type for the main button (default: none -> exit).\n      Example: -main_button_cta_type link",
+                                               "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -main_button_cta_payload \"URL\"",
+                                               "\n      The label of the secondary button.\n      Example: -secondary_button_label \"Secondary button title\"",
+                                               "[ none | link ]".red() + "\n      The call to action type for the secondary button (default: none -> exit).\n      Example: -secondary_button_cta_type link",
+                                               "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -secondary_button_cta_payload \"URL\"",
+                                               "\n      The label of the tertiary button.\n      Example: -tertiary_button_label \"Tertiary button title\"",
+                                               "[ none | link ]".red() + "\n      The call to action type for the tertiary button.\n      Example: -tertiary_button_cta_type link",
+                                               "\n      An URL if " + "[ link ]".red() + " cta type defined.\n      Example: -tertiary_button_cta_payload \"URL\""]
     static let onboardingDescriptions: [String] = ["[ onboarding ]".red() + "\n      The UI type of the notification.\n      Example: -type onboarding",
-                                              "\n      The json payload for the \"onboarding\" UI type.\n      Example: -payload \"{ \"pages\": [\n                                      {\n                                         \"title\": \"Some title\",\n                                         \"subtitle\": \"Some subtitle\",\n                                         \"body\": \"Some body\",\n                                         \"mediaType\": \"[ image | video ]\",\n                                         \"mediaPayload\": \"Some URL\"\n                                      }\n                                    ]\n                         }\"\n      Please see more about this feature on the project wiki."]
+                                                   "\n      The json payload for the \"onboarding\" UI type.\n      Example: -payload \"{ \"pages\": [\n                                      {\n                                         \"title\": \"Some title\",\n                                         \"subtitle\": \"Some subtitle\",\n                                         \"body\": \"Some body\",\n                                         \"mediaType\": \"[ image | video ]\",\n                                         \"mediaPayload\": \"Some URL\"\n                                      }\n                                    ]\n                         }\"\n      Please see more about this feature on the project wiki."]
     static let popupSyntacticRules: [String] = ["At least one argument between" + " [ -title | -subtitle | -accessory_view_type + -accessory_view_payload ] ".red() + "must be defined to present a pop-up.",
-                                           "By default tertiary button is not destructive. Use " + "[ exitlink ]".red() + " cta type to trigger a link (optional) and make it destructive for the pop-up.",
-                                          "In general if a call to action type is defined for a button, must be defined also the related payload. Except for the cta types " + "[ none | exitlink ]".red() + "."]
+                                                "By default tertiary button is not destructive. Use " + "[ exitlink ]".red() + " cta type to trigger a link (optional) and make it destructive for the pop-up.",
+                                                "In general if a call to action type is defined for a button, must be defined also the related payload. Except for the cta types " + "[ none | exitlink ]".red() + "."]
     static let bannerSyntacticRules: [String] = ["At least one argument between" + " [ -title | -subtitle ] ".red() + "must be defined to present a banner.",
-                                           "In general if a call to action type is defined for a button, must be defined also the related payload."]
+                                                 "In general if a call to action type is defined for a button, must be defined also the related payload."]
     static let popupNotes: [String] = ["If no call to action type defined for a button the default one is " + "[ none ]".red() + ", that simply return the exit code related to the clicked button.\n- \"/selected\" and \"/placeholder\" keys for " + "[ dropdown ]".red() + " accessory view payload are mutually exclusive."]
     static let bannerNotes: [String] = ["If no call to action type defined for a button the default one is " + "[ none ]".red() + ", that simply return the exit code related to the clicked button.\nAlert UI require additional configurations to work properly. Please refer to the related Github Wiki Page."]
     static let specialArguments: [String] = ["--help".blue(),
@@ -106,10 +106,10 @@ public final class HelpBuilder {
                                              "--privacy".blue(),
                                              "--v".blue()]
     static let specialArgumentsDescriptions: [String] = ["Show help's page",
-                                             "Show app's version",
-                                             "Shows the Terms & Conditions",
-                                             "Shows the Privacy Policy",
-                                             "Verbose mode"]
+                                                         "Show app's version",
+                                                         "Shows the Terms & Conditions",
+                                                         "Shows the Privacy Policy",
+                                                         "Verbose mode"]
     static let configurableParameters: [String] = ["-default_popup_bar_title".yellow(),
                                                    "-default_popup_icon_path".yellow(),
                                                    "-default_popup_timeout".yellow(),
@@ -119,43 +119,43 @@ public final class HelpBuilder {
                                                                "Default pop-up's background timeout.\n      Example: -default_popup_timeout 300",
                                                                "Default main button label.\n      Example: -default_main_button_label \"Label\""]
     static let popupReturnValues: [String] = ["0".bold(),
-                                         "1".bold(),
-                                         "2".bold(),
-                                         "3".bold(),
-                                         "4".bold(),
-                                         "200".bold(),
-                                         "201".bold(),
-                                         "250".bold(),
-                                         "255".bold(),
-                                         "260".bold()]
+                                              "1".bold(),
+                                              "2".bold(),
+                                              "3".bold(),
+                                              "4".bold(),
+                                              "200".bold(),
+                                              "201".bold(),
+                                              "250".bold(),
+                                              "255".bold(),
+                                              "260".bold()]
     static let popupReturnValuesDescription: [String] = ["Main button clicked.",
-                                                    "Internal error.",
-                                                    "Secondary button clicked.",
-                                                    "Tertiary button clicked.",
-                                                    "Timeout.",
-                                                    "Untracked success.",
-                                                    "Received SigInt.",
-                                                    "Invalid number of arguments.",
-                                                    "Invalid arguments syntax.",
-                                                    "Unable to load resources"]
+                                                         "Internal error.",
+                                                         "Secondary button clicked.",
+                                                         "Tertiary button clicked.",
+                                                         "Timeout.",
+                                                         "Untracked success.",
+                                                         "Received SigInt.",
+                                                         "Invalid number of arguments.",
+                                                         "Invalid arguments syntax.",
+                                                         "Unable to load resources"]
     static let bannerReturnValues: [String] = ["0".bold(),
-                                         "1".bold(),
-                                         "2".bold(),
-                                         "3".bold(),
-                                         "200".bold(),
-                                         "239".bold(),
-                                         "201".bold(),
-                                         "250".bold(),
-                                         "255".bold()]
+                                               "1".bold(),
+                                               "2".bold(),
+                                               "3".bold(),
+                                               "200".bold(),
+                                               "239".bold(),
+                                               "201".bold(),
+                                               "250".bold(),
+                                               "255".bold()]
     static let bannerReturnValuesDescription: [String] = ["Main button clicked.",
-                                                    "Internal error.",
-                                                    "Secondary button clicked.",
-                                                    "Tertiary button clicked.",
-                                                    "Untracked success.",
-                                                    "User dimissed the notification banner.",
-                                                    "Received SigInt.",
-                                                    "Invalid number of arguments.",
-                                                    "Invalid arguments syntax."]
+                                                          "Internal error.",
+                                                          "Secondary button clicked.",
+                                                          "Tertiary button clicked.",
+                                                          "Untracked success.",
+                                                          "User dimissed the notification banner.",
+                                                          "Received SigInt.",
+                                                          "Invalid number of arguments.",
+                                                          "Invalid arguments syntax."]
     static let onboardingReturnValues: [String] = ["0".bold(),
                                                    "239".bold()]
     static let onboardingReturnValuesDescription: [String] = ["User did finish onboarding.",
@@ -164,7 +164,7 @@ public final class HelpBuilder {
     static let exampleBanner: String = "~/IBM\\ Notifier.app/Contents/MacOS/IBM\\ Notifier -type banner -title \"Test title\" -subtitle \"Test subtitle\" -main_button_label \"Main button\" -secondary_button_label \"Secondary button\" -tertiary_button_label \"Tertiary button\" -tertiary_button_cta_type link -tertiary_button_cta_payload \"https://www.ibm.com\""
     static let exampleAlert: String = "~/IBM\\ Notifier.app/Contents/MacOS/IBM\\ Notifier -type alert -title \"Test title\" -subtitle \"Test subtitle\" -main_button_label \"Main button\" -secondary_button_label \"Secondary button\" -tertiary_button_label \"Tertiary button\" -tertiary_button_cta_type link -tertiary_button_cta_payload \"https://www.ibm.com\""
     static let exampleOnboarding: String = "~/IBM\\ Notifier.app/Contents/MacOS/IBM\\ Notifier -type onboarding -payload \"{\\\"pages\\\":[{\\\"title\\\":\\\"First page's title\\\",\\\"subtitle\\\":\\\"First page's subtitle\\\",\\\"body\\\":\\\"First page's body\\\",\\\"mediaType\\\":\\\"image\\\",\\\"mediaPayload\\\":\\\"http://image.address\\\"}]}\""
-
+    
     static func printHelp(_ arguments: [String]) {
         guard !arguments.contains("-popup") else {
             Self.printPopupHelp()
@@ -189,7 +189,7 @@ public final class HelpBuilder {
         print("\nIBM Notifier Help Page".bold().blue() + "\n")
         print("You can use:\n     --help -popup - To show help page about the pop-up UI;\n     --help -banner - To show help page about the banner (temporary banner notification) UI;\n     --help -alert - To show help page about the alert (persistent banner notification) UI;\n     --help -onboarding - To show help page about the onboarding UI;\n     --help -configuration - To show help page about the configuration mode.\n")
     }
-
+    
     static func printPopupHelp() {
         print("\nIBM Notifier Popup UI".bold().blue() + "\n")
         var argumentsString = ""
@@ -219,7 +219,7 @@ public final class HelpBuilder {
         print("- Popup UI - ".blue() + examplePopup)
         print("\n")
     }
-
+    
     static func printBannerHelp() {
         print("\nIBM Notifier Banner and Alert UIs".bold().blue() + "\n")
         var argumentsString = ""
@@ -246,7 +246,7 @@ public final class HelpBuilder {
         print("- Alert UI - ".blue() + exampleAlert)
         print("\n")
     }
-
+    
     static func printOnboardingHelp() {
         print("\nIBM Notifier Onboarding UI".bold().blue() + "\n")
         var argumentsString = ""
@@ -282,7 +282,7 @@ public final class HelpBuilder {
             print("\(configurableParameters[index]):\n      \(configurableParametersDescriptions[index])")
         }
     }
-
+    
     static func printNoArgumentsPage() {
         print("\nIBM Notifier".bold().blue() + "\n")
         for index in specialArguments.indices {
@@ -293,7 +293,7 @@ public final class HelpBuilder {
     static func printPrivacyPolicy() {
         guard let url = Bundle.main.url(forResource: "PRIVACY POLICY", withExtension: "rtf") else { return }
         let opts : [NSAttributedString.DocumentReadingOptionKey : Any] =
-            [.documentType : NSAttributedString.DocumentType.rtf]
+        [.documentType : NSAttributedString.DocumentType.rtf]
         var attributes : NSDictionary?
         if let attributedString = try? NSAttributedString(url: url, options: opts, documentAttributes: &attributes) {
             print(attributedString.string)
@@ -303,13 +303,13 @@ public final class HelpBuilder {
     static func printTermsAndCondition() {
         guard let url = Bundle.main.url(forResource: "TERMS AND CONDITIONS", withExtension: "rtf") else { return }
         let opts : [NSAttributedString.DocumentReadingOptionKey : Any] =
-            [.documentType : NSAttributedString.DocumentType.rtf]
+        [.documentType : NSAttributedString.DocumentType.rtf]
         var attributes : NSDictionary?
         if let attributedString = try? NSAttributedString(url: url, options: opts, documentAttributes: &attributes) {
             print(attributedString.string)
         }
     }
-
+    
     static func printAppVersion() {
         print("IBM Notifier version: \(Bundle.main.infoDictionary!["CFBundleShortVersionString"] as? String ?? "Unknown")".bold())
     }

--- a/Notification Agent Popups/Base.lproj/Main.storyboard
+++ b/Notification Agent Popups/Base.lproj/Main.storyboard
@@ -685,8 +685,8 @@
         <scene sceneID="hIz-AP-VOD">
             <objects>
                 <viewController identifier="popUpViewController" storyboardIdentifier="popUpViewController" id="XfG-lQ-9wD" customClass="PopUpViewController" customModule="IBM_Notifier_Popup" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" misplaced="YES" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="579" height="129"/>
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="529" height="129"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vWd-KW-45q">
@@ -694,7 +694,6 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" identifier="iconHeight" id="0O6-CR-q6S"/>
                                     <constraint firstAttribute="width" constant="60" identifier="iconWidth" id="Jvn-G7-sZe"/>
-                                    <constraint firstAttribute="width" secondItem="vWd-KW-45q" secondAttribute="height" multiplier="1:1" identifier="iconAspect" id="LaC-Ei-O4H"/>
                                 </constraints>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="default_icon" id="6x1-Vi-I8C"/>
                             </imageView>
@@ -764,11 +763,11 @@ DQ
                         <constraints>
                             <constraint firstItem="Pyp-Ls-xUg" firstAttribute="leading" secondItem="vWd-KW-45q" secondAttribute="trailing" constant="23" id="2no-2A-3As"/>
                             <constraint firstAttribute="bottom" secondItem="42Z-Y4-Bak" secondAttribute="bottom" constant="20" id="BIx-Tz-Qkr"/>
-                            <constraint firstItem="cPd-kS-72Q" firstAttribute="leading" secondItem="vWd-KW-45q" secondAttribute="trailing" constant="23" id="BM5-mX-Lhb"/>
                             <constraint firstItem="vWd-KW-45q" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="14" id="Chu-Oj-bMm"/>
                             <constraint firstAttribute="bottom" secondItem="cPd-kS-72Q" secondAttribute="bottom" constant="20" id="I0b-zE-vrd"/>
                             <constraint firstItem="42Z-Y4-Bak" firstAttribute="top" secondItem="Pyp-Ls-xUg" secondAttribute="bottom" constant="14" id="KFW-AJ-wHm"/>
-                            <constraint firstItem="cPd-kS-72Q" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="P1e-SU-bDD" secondAttribute="trailing" constant="12" symbolic="YES" id="NMV-MC-AFV"/>
+                            <constraint firstItem="cPd-kS-72Q" firstAttribute="leading" secondItem="P1e-SU-bDD" secondAttribute="trailing" constant="63" id="Q2N-GY-xgv"/>
+                            <constraint firstItem="42Z-Y4-Bak" firstAttribute="top" relation="greaterThanOrEqual" secondItem="vWd-KW-45q" secondAttribute="bottom" constant="14" id="SW7-Ow-0KH"/>
                             <constraint firstAttribute="trailing" secondItem="42Z-Y4-Bak" secondAttribute="trailing" constant="23" id="Xjv-sQ-VN8"/>
                             <constraint firstItem="vWd-KW-45q" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="23" id="hgx-Sj-nf7"/>
                             <constraint firstAttribute="bottom" secondItem="P1e-SU-bDD" secondAttribute="bottom" constant="20" id="htw-SD-aob"/>
@@ -784,6 +783,8 @@ DQ
                     <connections>
                         <outlet property="helpButton" destination="P1e-SU-bDD" id="rr9-Ts-8I3"/>
                         <outlet property="iconView" destination="vWd-KW-45q" id="qXK-6w-GOt"/>
+                        <outlet property="iconViewHeight" destination="0O6-CR-q6S" id="zhb-IC-feN"/>
+                        <outlet property="iconViewWidth" destination="Jvn-G7-sZe" id="5ja-La-gqZ"/>
                         <outlet property="mainButton" destination="42Z-Y4-Bak" id="ZwR-zM-I8Y"/>
                         <outlet property="popupElementsStackView" destination="Pyp-Ls-xUg" id="PHM-jW-ofA"/>
                         <outlet property="secondaryButton" destination="afi-PD-X0x" id="fps-O0-BFp"/>

--- a/Notification Agent Popups/Views/PopUpViewController.swift
+++ b/Notification Agent Popups/Views/PopUpViewController.swift
@@ -27,7 +27,9 @@ class PopUpViewController: NSViewController {
     @IBOutlet weak var secondaryButton: NSButton!
     @IBOutlet weak var tertiaryButton: NSButton!
     @IBOutlet weak var popupElementsStackView: NSStackView!
-
+    @IBOutlet weak var iconViewHeight: NSLayoutConstraint!
+    @IBOutlet weak var iconViewWidth: NSLayoutConstraint!
+    
     // MARK: - Variables
 
     var notificationObject: NotificationObject!
@@ -114,53 +116,19 @@ class PopUpViewController: NSViewController {
         } else {
             iconView.image = NSImage(named: NSImage.Name("default_icon"))
         }
-        
-        // set icon width and height if specified
-        var changedIconWidth = false
-        var changedIconHeight = false
-        var newIconHeight: CGFloat = 0
-        for constraint in iconView.constraints {
-            if constraint.identifier == "iconWidth" {
-                if let iconWidthAsString = notificationObject.iconWidth {
-                    if let customWidth = NumberFormatter().number(from: iconWidthAsString) {
-                        let iconWidth = CGFloat(truncating: customWidth)
-                        constraint.constant = iconWidth
-                        changedIconWidth = true
-                    }
-                }
-            } else if constraint.identifier == "iconHeight" {
-                if let iconHeightAsString = notificationObject.iconHeight {
-                    if let customHeight = NumberFormatter().number(from: iconHeightAsString) {
-                        let iconHeight = CGFloat(truncating: customHeight)
-                        constraint.constant = iconHeight
-                        changedIconHeight = true
-                        newIconHeight = iconHeight
-                    }
-                }
-            }
+        // Set icon width and height if specified
+        if let iconWidthAsString = notificationObject.iconWidth,
+           let customWidth = NumberFormatter().number(from: iconWidthAsString) {
+            iconViewWidth.constant = CGFloat(truncating: customWidth)
         }
-        
-        if changedIconHeight {
-            // make room in the popup for the icon
-            for constraint in popupElementsStackView.constraints {
-                if constraint.identifier == "popupHeight" {
-                    constraint.constant = newIconHeight
-                    break
-                }
-            }
+        if let iconHeightAsString = notificationObject.iconHeight,
+           let customHeight = NumberFormatter().number(from: iconHeightAsString) {
+            iconViewHeight.constant = CGFloat(truncating: customHeight)
         }
-        
-        if changedIconWidth || changedIconHeight {
-            for constraint in iconView.constraints {
-                if constraint.identifier == "iconAspect" {
-                    iconView.removeConstraint(constraint) // remove the 1:1 constraint
-                    iconView.imageScaling = .scaleAxesIndependently
-                    iconView.image?.resizingMode = .stretch
-                    break
-                }
-            }
+        if iconViewHeight.constant != iconViewWidth.constant {
+            iconView.imageScaling = .scaleAxesIndependently
+            iconView.image?.resizingMode = .stretch
         }
-        
         iconView.layout()
     }
     

--- a/Notification Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Notification Agent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Kitura/BlueCryptor.git",
         "state": {
           "branch": null,
-          "revision": "ee5880e031da4c609f372cf7472476ab51d5dd19",
-          "version": "1.0.200"
+          "revision": "88fc6e132f41ece53e49acc0e4f67b0331c15b90",
+          "version": "2.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Kitura/BlueRSA.git",
         "state": {
           "branch": null,
-          "revision": "c885fcdbe1b04718cb46d747387137653c030f6c",
-          "version": "1.0.200"
+          "revision": "440f78db26d8bb073f29590f1c7bd31004da09ae",
+          "version": "1.0.201"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Kitura/KituraContracts.git",
         "state": {
           "branch": null,
-          "revision": "8418006e39e2efae9b31ae92721cb597ac29c617",
-          "version": "1.2.200"
+          "revision": "8a4778c3aa7833e9e1af884e8819d436c237cd70",
+          "version": "1.2.201"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/Swift-JWT.git",
         "state": {
           "branch": null,
-          "revision": "2f2fc12ae88660e0760b04d9e6c341517b31ad7b",
-          "version": "3.6.200"
+          "revision": "47c6384b6923e9bb1f214d2ba4bd52af39440588",
+          "version": "3.6.201"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {

--- a/Shared/Model/UIObjects/NotificationObject.swift
+++ b/Shared/Model/UIObjects/NotificationObject.swift
@@ -180,6 +180,29 @@ public final class NotificationObject: NSObject, Codable, NSSecureCoding {
                     break
                 }
             }
+            func resetCustomIconSize(_ message: String) {
+                NALogger.shared.log("%{public}@", [message])
+                iconWidth = nil
+                iconHeight = nil
+            }
+            if let iconWidthAsString = iconWidth {
+                if let customWidth = NumberFormatter().number(from: iconWidthAsString) {
+                    if CGFloat(truncating: customWidth) > 150 {
+                        resetCustomIconSize("The desired custom icon size exceed the limits (Width: 150px, Height: 300px)")
+                    }
+                } else {
+                    resetCustomIconSize("Please check the format of -icon_width argument.")
+                }
+            }
+            if let iconHeightAsString = iconHeight {
+                if let customHeight = NumberFormatter().number(from: iconHeightAsString) {
+                    if CGFloat(truncating: customHeight) > 300 {
+                        resetCustomIconSize("The desired custom icon size exceed the limits (Width: 150px, Height: 300px)")
+                    }
+                } else {
+                    resetCustomIconSize("Please check the format of -icon_height argument.")
+                }
+            }
         case .onboarding:
             guard self.payload != nil else {
                 throw NAError.dataFormat(type: .invalidOnboardingPayload)


### PR DESCRIPTION
This changes come from the review of the [#66](https://github.com/IBM/mac-ibm-notifications/pull/66) pull request.

**Proposed changes:**
1. Set a limit on the custom size accepted for the icon to 150px for the width and 300px for the height, for design purposes; 
2. Shorten the code to set the custom size using Outlets for the related constraints instead of identifiers;
3. Set a constraint to avoid icon overlapping other elements without using the pop-up height;